### PR TITLE
Add invert option to allow checking if a value is less than a threshold

### DIFF
--- a/check_redis
+++ b/check_redis
@@ -16,6 +16,8 @@ OptionParser.new do |opt|
 
   opt.on("-w", "--warn WARN", Integer, "Nagios warning level") { |warn| options[:nagios][:warn] = warn }
   opt.on("-c", "--crit CRIT", Integer, "Nagios critical level") { |crit| options[:nagios][:crit] = crit }
+  options[:invert] = 0
+  opt.on('-i', '--invert', 'Invert the warning and critical thresholds (less than instead of greater than or equal to)') { |o| options[:invert] = 1 if o }
 
   opt.separator ""
   opt.separator "Connection options:"
@@ -59,7 +61,7 @@ class CheckRedis
       end
     end
 
-    check_result(value, opts[:nagios], cmd)
+    check_result(value, opts[:nagios], cmd, opts[:invert])
 
   rescue Errno::ECONNREFUSED => e
     puts e.message
@@ -80,12 +82,18 @@ class CheckRedis
 
   private
 
-  def check_result(value, options, cmd)
-      if value >= options[:crit]
+  def check_result(value, options, cmd, invert)
+      if invert == 0 && value >= options[:crit]
         puts "CRIT: #{cmd} exceeds critical level of #{options[:crit]} : #{value} | #{cmd}=#{value};#{options[:warn]};#{options[:crit]};;"
         exit 2
-      elsif value >= options[:warn]
+      elsif invert == 0 && value >= options[:warn]
         puts "WARN: #{cmd} exceeds warning level of #{options[:warn]} : #{value} | #{cmd}=#{value};#{options[:warn]};#{options[:crit]};;"
+        exit 1
+      elsif invert == 1 && value < options[:crit]
+        puts "WARN: #{cmd} is lower than the critical level of #{options[:crit]} : #{value} | #{cmd}=#{value};#{options[:warn]};#{options[:crit]};;"
+        exit 2
+      elsif invert == 1 && value < options[:warn]
+        puts "WARN: #{cmd} is lower than warning level of #{options[:warn]} : #{value} | #{cmd}=#{value};#{options[:warn]};#{options[:crit]};;"
         exit 1
       else
         puts "OK: #{cmd} is ok | #{cmd}=#{value};#{options[:warn]};#{options[:crit]};;"


### PR DESCRIPTION
We needed the ability to check whether certain stats were below a threshold rather than equal to or greater than.  I added an invert option that will do just that.  Take this traditional check:

```
./check_redis connected_clients -H <host> -w 6 -c 10
```

In the normal operation this would alert warning if there were >= 6 clients and critical if >= 10 clients.  If you simply add a -i option (and reverse the w and c thresholds so they make sense):

```
./check_redis connected_clients -H <host> -w 10 -c 6 -i 
```

we can now alert warning if there are less than 10 clients and critical if there are less than 6 clients (Not checking equal to on inversion since it's checked on the normal operation)

I don't know if you'll find this useful for inclusion in this project but I wanted to contribute upstream in case.  Thanks for your consideration!
